### PR TITLE
Use https on API call

### DIFF
--- a/mindmeister2md.rb
+++ b/mindmeister2md.rb
@@ -42,7 +42,7 @@ def dump_config (config)
 end
 
 def rest_call(param)
-  url = URI::HTTP.build({:host => $host, :path => "/services/rest", :query => param})
+  url = URI::HTTPS.build({:host => $host, :path => "/services/rest", :query => param})
   Net::HTTP.get_response(url).body
 end  
 


### PR DESCRIPTION
Mindmeister API now redirects HTTP calls to HTTPS. NET::HTTP doesn't follow the redirect and returns an empty body, resulting in nilclass errors on every API call. This changes the API calls to https.